### PR TITLE
V2.13.2 jdk25

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Perform various operations on PDF files
 
 [![🌐 Official app website](https://img.shields.io/badge/Official_app_website-darkgreen?style=for-the-badge)](https://www.stirlingpdf.com/)
 [![App Demo](https://img.shields.io/badge/App_Demo-blue?style=for-the-badge)](https://stirlingpdf.io/)
-[![Version: 2.11.0~ynh1](https://img.shields.io/badge/Version-2.11.0~ynh1-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/stirling-pdf/)
+[![Version: 2.13.2~ynh1](https://img.shields.io/badge/Version-2.13.2~ynh1-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/stirling-pdf/)
 
 <div align="center">
 <a href="https://apps.yunohost.org/app/stirling-pdf"><img height="100px" src="https://github.com/YunoHost/yunohost-artwork/raw/refs/heads/main/badges/neopossum-badges/badge_more_info_on_the_appstore.svg"/></a>

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Stirling PDF"
 description.en = "Perform various operations on PDF files"
 description.fr = "Effectuez diverses opérations sur des fichiers PDF"
 
-version = "2.11.0~ynh1"
+version = "2.13.2~ynh1"
 
 maintainers = []
 
@@ -54,8 +54,8 @@ ram.runtime = "400M"
     [resources.sources.main]
     in_subdir = false
     rename= "Stirling-PDF.jar"
-    url = "https://github.com/Stirling-Tools/Stirling-PDF/releases/download/v2.11.0/Stirling-PDF.jar"
-    sha256 = "9f240b50180979206ae72604101bf444c3cc5f573577419aaf5f97055d82ebbd"
+    url = "https://github.com/Stirling-Tools/Stirling-PDF/releases/download/v2.13.2/Stirling-PDF.jar"
+    sha256 = "96d665c710183756b23c3c72f97829f637e1f2e0d1b89607a5333c23b6b80f0a"
 
     autoupdate.strategy = "latest_github_release"
     autoupdate.asset = "Stirling-PDF.jar"

--- a/manifest.toml
+++ b/manifest.toml
@@ -61,13 +61,13 @@ ram.runtime = "400M"
     autoupdate.asset = "Stirling-PDF.jar"
 
     [resources.sources.jdk]
-    amd64.url = "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.11%2B10/OpenJDK21U-jdk_x64_linux_hotspot_21.0.11_10.tar.gz"
-    amd64.sha256 = "4b2220e232a97997b436ca6ab15cbf70171ecff52958a46159dfa5a8c44ca4de"
-    arm64.url = "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.11%2B10/OpenJDK21U-jdk_aarch64_linux_hotspot_21.0.11_10.tar.gz"
-    arm64.sha256 = "8d498ec88e1c1989fab95c6784240ab92d011e29c54d20a3f9c324b13476f9ad"
+    amd64.url = "https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.3%2B9/OpenJDK25U-jdk_x64_linux_hotspot_25.0.3_9.tar.gz"
+    amd64.sha256 = "69264a7a211bf5029830d07bc3370f879769d62ebc5b5488e90c9343a2da0e1f"
+    arm64.url = "https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.3%2B9/OpenJDK25U-jdk_aarch64_linux_hotspot_25.0.3_9.tar.gz"
+    arm64.sha256 = "3e4287cb98870ba824ed698854bdc27cff984254caf66dd12cc291e7bfdde26b"
     autoupdate.strategy = "latest_github_release"
     autoupdate.version_regex = "jdk-(\\d+\\.\\d+\\.\\d+)\\+(.*)"
-    autoupdate.upstream = "https://github.com/adoptium/temurin21-binaries"
+    autoupdate.upstream = "https://github.com/adoptium/temurin25-binaries"
     autoupdate.asset.amd64 = "OpenJDK.*-jdk_x64_linux_hotspot_.*\\.tar\\.gz$"
     autoupdate.asset.arm64 = "OpenJDK.*-jdk_aarch64_linux_hotspot_.*\\.tar\\.gz$"
 


### PR DESCRIPTION
## Problem

- *Jun 24 23:58:51 java[3744]: Exception in thread "main" java.lang.UnsupportedClassVersionError: stirling/software/SPDF/SPDFApplication has been compiled by a more recent version of the Java Runtime (class file version 69.0), this version of the Java Runtime only recognizes class file versions up to 65.0*
https://ci-apps-dev.yunohost.org/ci/logs/22158.log

## Solution

- *Try to update jdk 21 to jdk 25 because jdk 25 - LTS is this the latest release*
https://adoptium.net/fr/temurin/releases

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
